### PR TITLE
More DEI fixes: fix typos; see also PR #17

### DIFF
--- a/dei-lessons/1_social_identities.md
+++ b/dei-lessons/1_social_identities.md
@@ -34,7 +34,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Recognizing Privilege](https://epicenter.epicodus.com/journals?title=Social+Identities)**
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 

--- a/dei-lessons/1_social_identities.md
+++ b/dei-lessons/1_social_identities.md
@@ -32,7 +32,7 @@ Take a moment to think about your social identities. Which ones are more hidden 
 
 There is a reflective assignment for this lesson. If you are ready to write your reflection, head on over to Epicenter to find the prompt. If you are logged in to Epicenter, you can access the prompt by navigating to this link:
 
-**<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Recognizing Privilege](https://epicenter.epicodus.com/journals?title=Social+Identities)**
+**<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Social Identities](https://epicenter.epicodus.com/journals?title=Social+Identities)**
 
 Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 

--- a/dei-lessons/2_identifying_and_preventing_microaggressions.md
+++ b/dei-lessons/2_identifying_and_preventing_microaggressions.md
@@ -161,7 +161,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Identifying and Preventing Microaggressions](https://epicenter.epicodus.com/journals?title=Identifying+and+Preventing+Microaggressions)** 
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 

--- a/dei-lessons/3_equity_vs_equality.md
+++ b/dei-lessons/3_equity_vs_equality.md
@@ -26,7 +26,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Equality Versus Equity](https://epicenter.epicodus.com/journals?title=Equality+Versus+Equity)** 
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 

--- a/dei-lessons/3_imposter_syndrome.md
+++ b/dei-lessons/3_imposter_syndrome.md
@@ -85,7 +85,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Imposter Syndrome](https://epicenter.epicodus.com/journals?title=Imposter+Syndrome)** 
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 

--- a/dei-lessons/3_recognizing_privilege.md
+++ b/dei-lessons/3_recognizing_privilege.md
@@ -56,7 +56,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Recognizing Privilege](https://epicenter.epicodus.com/journals?title=Recognizing+Privilege)** 
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 

--- a/dei-lessons/4_asking_and_listening.md
+++ b/dei-lessons/4_asking_and_listening.md
@@ -79,7 +79,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Asking and Listening](https://epicenter.epicodus.com/journals?title=Asking+and+Listening)** 
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 

--- a/dei-lessons/5_speaking_up.md
+++ b/dei-lessons/5_speaking_up.md
@@ -70,7 +70,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Speaking Up](https://epicenter.epicodus.com/journals?title=Speaking+Up)** 
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 

--- a/dei-lessons/8_jokes_and_humor.md
+++ b/dei-lessons/8_jokes_and_humor.md
@@ -29,7 +29,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Jokes and Appropriate Humor](https://epicenter.epicodus.com/journals?title=Jokes+and+Appropriate+Humor)** 
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 

--- a/dei-lessons/addressing_implicit_bias.md
+++ b/dei-lessons/addressing_implicit_bias.md
@@ -36,7 +36,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Addressing Implicit Bias](https://epicenter.epicodus.com/journals?title=Addressing+Implicit+Bias)** 
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 

--- a/dei-lessons/changing_master_to_main_gh.md
+++ b/dei-lessons/changing_master_to_main_gh.md
@@ -65,7 +65,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Inclusive Terminology and Using a Main Branch](https://epicenter.epicodus.com/journals?title=Inclusive+Terminology:+Using+a+Main+Branch)** 
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 

--- a/dei-lessons/economic_benefits_of_diversity_in_tech.md
+++ b/dei-lessons/economic_benefits_of_diversity_in_tech.md
@@ -26,7 +26,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Economic Benefits of Diversity in Tech](https://epicenter.epicodus.com/journals?title=Economic+Benefits+of+Diversity+in+Tech)** 
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 

--- a/dei-lessons/understanding_stereotype_threat.md
+++ b/dei-lessons/understanding_stereotype_threat.md
@@ -24,7 +24,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Understanding Stereotype Threat](https://epicenter.epicodus.com/journals?title=Understanding+Stereotype+Threat)** 
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 

--- a/not-in-use/0_intro_to_dei_talks.md
+++ b/not-in-use/0_intro_to_dei_talks.md
@@ -55,7 +55,7 @@ There is a reflective assignment for this lesson. If you are ready to write your
 
 **<span class="glyphicon glyphicon-link"></span> [Reflection Prompt: Introduction to DEI Curriculum](https://epicenter.epicodus.com/journals?title=Introduction+to+DEI+Curriculum)** 
 
-Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/diversity-equity-and-inclusion-reflective-assignments#finding-the-reflection-prompts) lesson.
+Otherwise, you can find detailed instructions on accessing the reflection prompts in the [DEI Reflective Assignments](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/dei-reflective-assignments#finding-the-reflection-prompts) lesson.
 
 ### [Do you have feedback?](#do-you-have-feedback)
 At the end of each DEI lesson, you’ll find this section. We welcome your feedback and want to hear about your experience of the DEI curriculum, discussions and workshops. We outline all of the ways you can give feedback in [the student handbook](https://www.learnhowtoprogram.com/introduction-to-programming/getting-started-at-epicodus/student-handbook#giving-feedback).


### PR DESCRIPTION
This PR:
- fixes a broken link across all DEI lessons
- fixes a typo regarding an incorrect reference in the "social identities" lesson

See also PR #17 